### PR TITLE
Page-title types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Then this script adds gts support (via `ember-template-imports`) and configures 
 - https://github.com/gitKrystan/prettier-plugin-ember-template-tag?tab=readme-ov-file#usage
 - https://typed-ember.gitbook.io/glint/environments/ember/installation
 
-This is just a time saver I use for bootstrapping new projects. YMMV
+This is just a time saver I use for bootstrapping new projects. I only run this with new projects and try to keep it up to date with the latest Ember release. I tested this with Ember 5.6.0. YMMV

--- a/files/types/global.d.ts
+++ b/files/types/global.d.ts
@@ -1,12 +1,9 @@
 import '@glint/environment-ember-loose';
-import { ComponentLike, HelperLike } from '@glint/template';
+import { ComponentLike } from '@glint/template';
+import type EmberPageTitleTemplateRegistry from 'ember-page-title/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
+  export default interface Registry extends EmberPageTitleTemplateRegistry {
     WelcomePage: ComponentLike;
-    'page-title': HelperLike<{
-      Args: { Positional: [title: string] };
-      Return: void;
-    }>;
   }
 }

--- a/index.js
+++ b/index.js
@@ -36,10 +36,13 @@ export default async function run() {
   log('Adding dependencies');
 
   const newDependencies = {
-    '@glint/core': '^1.2.1',
-    '@glint/environment-ember-template-imports': '^1.2.1',
+    '@glint/core': '^1.3.0',
+    '@glint/environment-ember-loose': '^1.3.0',
+    '@glint/template': '^1.3.0',
+    '@glint/environment-ember-template-imports': '^1.3.0',
     'ember-template-imports': '^4.0.0',
-    'prettier-plugin-ember-template-tag': '^1.1.0',
+    'prettier-plugin-ember-template-tag': '^2.0.0',
+    'ember-page-title': '^8.2.1',
   };
 
   await checkDependencies(newDependencies);
@@ -123,6 +126,9 @@ export default async function run() {
 
   // UPDATE TYPE REGISTRY (page-title)
   //---------------------------------------------
+  // NOTE: As of Ember 5.6, the types/global.d.ts file has a single import for
+  // @glint/environment-ember-loose. This will replace the file with a new one
+  // with the same import and some new stuff.
 
   log('Updating types/global.d.ts');
 


### PR DESCRIPTION
Updates global types registry to use types from ember-page-title.

Fixes #1 